### PR TITLE
Redirect to www.cantstopcolumbus.com, the official CSC website

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="COVID-19 Open Movement in Columbus" />
+  <meta http-equiv="refresh" content="0;URL='https://www.cantstopcolumbus.com/'" />
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">


### PR DESCRIPTION
The current organizers of Can't Stop Columbus would like to get this old site redirected to the new official site. I'm recommending adding a meta refresh tag to accomplish that unless someone can offer another solution.